### PR TITLE
Added front matter to tutorial and fixed apostrophes 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ author:
 description: 
 baseurl: ""
 collections:
-  
+encoding: "UTF-8"

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,3 +1,7 @@
+---
+title: Tutorial
+---
+<meta charset="utf-8">
 # Tutorial
 
 This runs through the basics of creating living documents using Concordion. 
@@ -32,7 +36,9 @@ The first step is to create a specification of the new feature. In the `src/test
 This uses a formatting language called Markdown, which makes it easy to create rich documents using plain text. 
 The `#` characters at the start of the line create headings, where the heading level is determined by the number of `#` characters.
 
-Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/authoring/src/test/resources/marketing/mailshots/SplittingNames.md) in Github, or in an editor that supports Markdown, we see it looks like ![preview of initial specification](img/tutorial-authored-preview.png)
+Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/authoring/src/test/resources/marketing/mailshots/SplittingNames.md) in Github, or in an editor that supports Markdown, we see it looks like
+
+![preview of initial specification](img/tutorial-authored-preview.png)
 
 The team are happy with the specification, so we share it (for example, by adding the file to our version control system).
 
@@ -46,7 +52,9 @@ The first step is to select the parts of the example that relate to _context_ (p
 
     The full name [Jane Smith]() is [broken]() into first name [Jane]() and last name [Smith]().
 
-Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/instrumenting-links/src/test/resources/marketing/mailshots/SplittingNames.md), we now see the example looks like ![preview of specification with links](img/tutorial-instrument-links-preview.png)
+Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/instrumenting-links/src/test/resources/marketing/mailshots/SplittingNames.md), we now see the example looks like 
+
+![preview of specification with links](img/tutorial-instrument-links-preview.png)
 
 Next, we add commands to the links:
 
@@ -59,7 +67,9 @@ These commands are:
 2. executing our _action_, by executing the method `split()` with the variable `#name` and returning the value `#result`
 3. verifying our _outcomes_, by checking whether `#result.firstName` is set to `Jane`, and `#result.lastName` is set to `Smith`.
 
-Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/instrumenting-commands/src/test/resources/marketing/mailshots/SplittingNames.md), we can hover over the links to see the command on each link ![preview of instrumented specification](img/tutorial-instrumented-preview.png).
+Previewing our [specification](https://github.com/concordion/concordion-tutorial-2.0/blob/instrumenting-commands/src/test/resources/marketing/mailshots/SplittingNames.md), we can hover over the links to see the command on each link 
+
+![preview of instrumented specification](img/tutorial-instrumented-preview.png).
 
 [Find out more](/instrumenting) about instrumenting fixtures.
 
@@ -80,6 +90,7 @@ In the `src/test/java/marketing/mailshots` folder of the tutorial project, creat
     }
 
 You may have noticed that the fixture is implemented as a JUnit runner. If you run the fixture as a JUnit test, the output should look something like this:
+
 <!-- TODO copy to img folder -->
 ![output broken due to missing code](http://concordion.org/image/tutorial/execute/BrokenDueToMissingFixtureCode.png)
 


### PR DESCRIPTION
(required UTF-8 encoding)

Tutorial should now be available at concordion.github.io/concordion-website-2.0/tutorial. Might need to configure Jekyll sites to get the /tutorial link to point to this?
