### PR TITLE
Cubano web driver

### DIFF
--- a/cubano/browser/firefox.md
+++ b/cubano/browser/firefox.md
@@ -7,7 +7,7 @@ sitemap:
 
 # FireFox
 
-Options for the various [FirefoxDriver](https://github.com/SeleniumHQ/selenium/wiki/FirefoxDriver) settings are at TODO ???? 
+Options for the various [FirefoxDriver](https://github.com/SeleniumHQ/selenium/wiki/FirefoxDriver) settings. 
 
 [https://stackoverflow.com/questions/42529853/list-of-firefox-and-chrome-arguments-preferences](https://stackoverflow.com/questions/42529853/list-of-firefox-and-chrome-arguments-preferences)
 
@@ -19,16 +19,23 @@ Check [https://github.com/mozilla/geckodriver/releases](https://github.com/mozil
 
 [Firefox Portable](https://portableapps.com/apps/internet/firefox_portable) can also be used and is a great choice if you need a different version than your installed Firefox version for any reason. 
 
-As with Firefox, any versions prior to 48 will need the legacy flag set to true, see configuration section below for more details. Note: FirefoxPortable 47 has a bug an will not work with Selenium WebDriver. FirefoxPortable 47.0.1 works fine.
+As with Firefox, any versions prior to 48 will need the legacy flag (firefox.useLegacyDriver), set to true, see configuration section below for more details. Note: FirefoxPortable 47 has a bug and will not work with Selenium WebDriver. FirefoxPortable 47.0.1 works fine.
   
-You will need to specify the location of the executable using the firefox.exe configuration property:
+You will need to specify the location of the executable using the firefox.exe configuration property. See configuration section below.  And in some corporate environments you may have to rename the executable to get around polices that block FirefoxPortable.exe (e.g. renaming to FF.exe works fine).
 
-* In some corporate environments you may have to rename the executable to get around polices that block FirefoxPortable.exe.
-* From version 48 onwards (ie when using the marionette/gecko driver) make sure you are pointing to "\path\to\FirefoxPortable\App\Firefox64\firefox.exe" and not just "\path\to\FirefoxPortable\FirefoxPortable.exe"
+### For Firefox versions < 48
+* Make sure `firefox.exe` is pointing to `\path\to\FirefoxPortable\FF.exe`  (assuming renamed to FF.exe)
 
-You'll may also want to configure Firefox Portable to run any time, regardless of how many other instances of Firefox or FirefoxPortable that are running:
-  
-1. Copy FirefoxPortable.ini from FirefoxPortable\Other\Source to FirefoxPortable\
+To configure Firefox Portable to run any time, regardless of how many other instances of Firefox or FirefoxPortable that are running:
+1. Copy FirefoxPortable.ini from `FirefoxPortable\Other\Source` to `FirefoxPortable\`
+1. Edit FirefoxPortable.ini and change AllowMultipleInstances=false to AllowMultipleInstances=true
+
+### For Firefox versions => 48
+* Make sure `firefox.exe` is pointing to `\path\to\FirefoxPortable\App\Firefox64\FF.exe` (assuming renamed to FF.exe)
+* From version 48 onwards we are using the marionette/gecko driver
+
+To configure Firefox Portable to run any time, regardless of how many other instances of Firefox or FirefoxPortable that are running:
+1. Copy FirefoxPortable.ini from `FirefoxPortable\Other\Source` to `\path\to\FirefoxPortable\App\Firefox64\`
 1. Edit FirefoxPortable.ini and change AllowMultipleInstances=false to AllowMultipleInstances=true
 
 ## Proxy Configuration

--- a/cubano/browser/ie.md
+++ b/cubano/browser/ie.md
@@ -7,7 +7,7 @@ sitemap:
 
 # Internet Explorer
 
-Options for the various [InternetExplorerDriver](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver) settings are at TODO ?where?
+Options for the various [InternetExplorerDriver](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver) settings.
 
 There is some configuration that must be done to Internet Explorer before it can be used by Selenium WebDriver, these steps are described [here](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-configuration).
 
@@ -21,4 +21,4 @@ InternetExplorerDriver properties describe many of the capabilities that can be 
 
 
 ## Troubleshooting
-sendkeys can be very slow (1-2 seconds per character): Mostly likely that is because the IE 32 bit version is being loaded and using 64 bit driver. Use `wdm.architecture=32`. The `ie.capability.requireWindowFocus = true` setting can also fix the problem.
+sendkeys can be very slow (1-2 seconds per character): Mostly likely that is because the IE 32 bit version is being loaded and using 64 bit driver. Use `wdm.architecture=X32`. The `ie.capability.requireWindowFocus = true` setting can also fix the problem.

--- a/cubano/browser/providers.md
+++ b/cubano/browser/providers.md
@@ -124,6 +124,10 @@ Number of tests to run before restarting browser.  Firefox 48+ with gecko driver
 
 * Defaults to 0 - Only close browser once all tests are completed
 
+##### webdriver.browserdriver.cleanup
+If set to true will run taskkill on windows, or pkill on linux based systems to terminate any running Selenium browser drivers. Note, this will not close any browsers, just the drivers. 
+* Defaults to false, allowed values are true or false
+
 ##### proxy.required
 
 If true then the proxy will be set on the requested browser

--- a/cubano/getting-started.md
+++ b/cubano/getting-started.md
@@ -5,5 +5,4 @@ sitemap:
     priority: 0.7
 ---
 
-Add something here...
-Point to example project
+Take a look at the [Cubano Demo project](https://github.com/concordion/cubano-demo) and then pull down the [Cubano Template project](https://github.com/concordion/cubano-template) to get started.


### PR DESCRIPTION
Completed some tidy ups on the Cubano doco.
1. Fixed some ambiguous info on the use of config for FirefoxPortable
2. Corrected a couple of items on the IE page
3. Includes Andrews previous commit for webdriver.browserdriver.cleanup
4. Added the Cubano-Template and Cubano-Demo projects to the getting started page.