### PR TITLE
Show GitHub stars

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
             <ul class="read-more">
                 <li><a class="white-text" target="_blank" href="https://twitter.com/concordion"><i class="fa fa-twitter white-text"></i>Follow us on Twitter</a></li>
                 <li><a class="white-text" target="_blank" href="https://groups.google.com/forum/#!forum/concordion"><i class="fa fa-google white-text"></i>Join our Google Group</a></li>
-                <li><a class="white-text" target="_blank" href="https://github.com/concordion/{{ repo }}"><i class="fa fa-github white-text"></i>Github&nbsp;</a><a class="github-button" href="https://github.com/concordion/{{ repo }}" data-icon="octicon-star" data-count-href="/concordion/{{ repo }}/stargazers" data-count-api="/repos/concordion/{{ repo }}#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star concordion/{{ repo }} on GitHub">Star</a></li>
+                <li><a class="white-text" target="_blank" href="https://github.com/concordion/{{ repo }}"><i class="fa fa-github white-text"></i>Github&nbsp;</a><a class="github-button" href="https://github.com/concordion/{{ repo }}" data-icon="octicon-star" data-show-count="true" data-count-href="/concordion/{{ repo }}/stargazers" data-count-api="/repos/concordion/{{ repo }}#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star concordion/{{ repo }} on GitHub">Star</a></li>
             </ul>
         </div>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
             <ul class="read-more">
                 <li><a class="white-text" target="_blank" href="https://twitter.com/concordion"><i class="fa fa-twitter white-text"></i>Follow us on Twitter</a></li>
                 <li><a class="white-text" target="_blank" href="https://groups.google.com/forum/#!forum/concordion"><i class="fa fa-google white-text"></i>Join our Google Group</a></li>
-                <li><a class="white-text" target="_blank" href="https://github.com/concordion/{{ repo }}"><i class="fa fa-github white-text"></i>Github</a><a class="github-button" href="https://github.com/concordion/{{ repo }}" data-icon="octicon-star" data-count-href="/concordion/{{ repo }}/stargazers" data-count-api="/repos/concordion/{{ repo }}#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star concordion/{{ repo }} on GitHub">Star</a></li>
+                <li><a class="white-text" target="_blank" href="https://github.com/concordion/{{ repo }}"><i class="fa fa-github white-text"></i>Github&nbsp;</a><a class="github-button" href="https://github.com/concordion/{{ repo }}" data-icon="octicon-star" data-count-href="/concordion/{{ repo }}/stargazers" data-count-api="/repos/concordion/{{ repo }}#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star concordion/{{ repo }} on GitHub">Star</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Ensure that the count of Github stars is shown after the `* Star` label. Fixes #78.