### PR TITLE
Added page linked to from Concordion namespace name

### DIFF
--- a/2007/concordion/index.md
+++ b/2007/concordion/index.md
@@ -1,0 +1,10 @@
+---
+title: "Concordion Namespace"
+heading: Concordion Namespace
+layout: sidenav
+---
+The namespace name `http://concordion.org/2007/concordion` is intended for use in Concordion specifications.
+
+See [Instrumenting Specifications](https://concordion.org/instrumenting/java/html/#overview) for details of how to use this namespace.
+
+<i>Note that this is a namespace name. Concordion specifications extend the XHTML schema with custom attributes in this namespace. There is no XML Schema definition specific to Concordion. </i>


### PR DESCRIPTION
Clarifies that this link is a namespace name not an XML Schema definition. Addresses #91. 